### PR TITLE
feat: Category, Product, Option, OptionCombination 등 Entity 정의

### DIFF
--- a/product/src/main/java/com/commerce/product/category/domain/Category.java
+++ b/product/src/main/java/com/commerce/product/category/domain/Category.java
@@ -1,0 +1,35 @@
+package com.commerce.product.category.domain;
+
+import com.commerce.product.category.dto.CreateCategory;
+import com.commerce.product.category.type.CategoryStatus;
+import com.commerce.product.common.aduit.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@ToString
+public class Category extends BaseEntity {
+
+    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private Double feeRate;
+    private Long parentCategoryId;
+
+    @Enumerated(value = EnumType.STRING)
+    private CategoryStatus status;
+
+    public static Category of(CreateCategory.Request request) {
+        return Category.builder()
+                .name(request.getName())
+                .feeRate(request.getFeeRate())
+                .parentCategoryId(request.getParentCategoryId())
+                .build();
+    }
+}

--- a/product/src/main/java/com/commerce/product/category/exception/CategoryExceptionCode.java
+++ b/product/src/main/java/com/commerce/product/category/exception/CategoryExceptionCode.java
@@ -1,0 +1,12 @@
+package com.commerce.product.category.exception;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum CategoryExceptionCode {
+
+    NOT_FOUND_CATEGORY("C001", "카테고리를 찾지 못하였습니다.");
+
+    private final String code;
+    private final String message;
+}

--- a/product/src/main/java/com/commerce/product/product/domain/Option.java
+++ b/product/src/main/java/com/commerce/product/product/domain/Option.java
@@ -1,0 +1,16 @@
+package com.commerce.product.product.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+public class Option {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String optionValue; // 구분자 ,로 구분
+    @ManyToOne
+    @JoinColumn(name ="product_id")
+    private Product product;
+}

--- a/product/src/main/java/com/commerce/product/product/domain/OptionCombination.java
+++ b/product/src/main/java/com/commerce/product/product/domain/OptionCombination.java
@@ -1,0 +1,18 @@
+package com.commerce.product.product.domain;
+
+import jakarta.persistence.*;
+
+@Entity
+public class OptionCombination {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String optionValue;
+    private Long stock;
+    private String price;
+    @ManyToOne
+    @JoinColumn(name = "product_id")
+    private Product product;
+}

--- a/product/src/main/java/com/commerce/product/product/domain/Product.java
+++ b/product/src/main/java/com/commerce/product/product/domain/Product.java
@@ -1,0 +1,19 @@
+package com.commerce.product.product.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Product {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private Long categoryId;
+    private String description;
+
+
+}


### PR DESCRIPTION
Entity 정의를 하고 Category 생성까지 구현했습니다. 

질문 
1. Category, Product 등 Entity 객체를 생성하여 저장할 때, 저는 보통 Controller에서 받은 dto를 Category의 static 메소드로 Category객체로 변환하고는 하는데 그럼 dto가 Service와 Entity에 의존성을 가지게 되는 것이 문제될 것 같은데 사실 아직 문제를 찾지는 못해서 그렇게 사용하고 있습니다. 이 방식이 잘못된 것인지 궁금합니다.
2. Entity를 정의하면서 Option과 OptionCombination을 정의했는데 쿠팡에서는 Option을 최대 3개까지 둘 수 있고 Option의 값을 제한없이 받게 됩니다. 그럼 최대 n^3개의 가짓수가 나오게 되고, n^3개에 각각 금액과 수량을 지정할 수 있습니다. 저는 OptionCombination이라는 클래스를 통해 optionValue필드에서 스트링으로 저장(예시 : 색상(빨강, 파랑), 사이즈(250, 260, 270, 280), 가죽(소가죽, 돼지가죽) 의 경우 "빨강 260 소가죽"으로 저장) 하고자 하는데 이런 방법이 맞는지 의문이 들게 되었습니다. 다른 방법은 너무 복잡하고 성능도 떨어질 것 같아 이런 결정을 하였는데 이럴 경우 데이터가 계속 중복으로 저장되는 부분에 대한 고민이 들게 되었습니다. 이런 부분에 대해 멘토님의 생각을 듣고 싶습니다!