### PR TITLE
fix: Entity 클래스 @OneToMany 단방향으로 설계변경

### DIFF
--- a/product/src/main/java/com/commerce/product/product/domain/Option.java
+++ b/product/src/main/java/com/commerce/product/product/domain/Option.java
@@ -1,13 +1,11 @@
 package com.commerce.product.product.domain;
 
 import com.commerce.product.product.dto.CreateOption;
-import com.commerce.product.product.dto.CreateProduct;
 import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -15,6 +13,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@ToString
 public class Option {
 
     @Id
@@ -22,30 +21,23 @@ public class Option {
     private Long optionId;
     private String name;
 
-    @ManyToOne
-    @JoinColumn(name = "product_id")
-    private Product product;
+    @Builder.Default
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "option_id", nullable = false, updatable = false)
+    private List<OptionValue> optionValues = new ArrayList<>();
 
-/*    @Builder.Default
-    @OneToMany(mappedBy = "option", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<OptionValue> optionValues = new ArrayList<>();*/
-/*
-
-    public static Option of(CreateOption.Request optionDto, CreateProduct.Request productDto) {
-        List<OptionValue> optionValues = optionDto.getOptionValues().stream()
-                .map(o -> OptionValue.of(o))
-                .collect(Collectors.toList());
-        return Option.builder()
-                .name(optionDto.getOptionName())
-                .optionValues(optionValues)
-                .build();
+    public void addOptionValue(OptionValue optionValue) {
+        optionValues.add(optionValue);
     }
-*/
 
     public static Option of(CreateOption.Request optionDto) {
-        return Option.builder()
+        Option option = Option.builder()
                 .name(optionDto.getOptionName())
                 .build();
-    }
 
+        optionDto.getOptionValues()
+                .forEach(o -> option.addOptionValue(OptionValue.of(o)));
+
+        return option;
+    }
 }

--- a/product/src/main/java/com/commerce/product/product/domain/OptionCombination.java
+++ b/product/src/main/java/com/commerce/product/product/domain/OptionCombination.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Setter
@@ -14,7 +13,7 @@ import java.util.stream.Collectors;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-//@ToString
+@ToString
 public class OptionCombination {
 
     @Id
@@ -23,33 +22,23 @@ public class OptionCombination {
     private Integer stock;
     private Integer price;
 
-    @ManyToOne
-    @JoinColumn(name = "product_id")
-    private Product product;
-
-/*
     @Builder.Default
-    @OneToMany(mappedBy = "optionCombination", cascade = CascadeType.ALL, orphanRemoval = true)
-//    @JoinColumn(name = "option_combination_id")
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "option_combination_id", nullable = false, updatable = false)
     private List<OptionCombinationValue> values = new ArrayList<>();
-*/
 
-    public static OptionCombination of(CreateOptionCombination.Request request, List<OptionValue> optionValues) {
-        List<OptionCombinationValue> optionCombinationValueList = request.getOptionCombinationValues().stream()
-                .map(o -> OptionCombinationValue.of(o, optionValues))
-                .collect(Collectors.toList());
-
-        return OptionCombination.builder()
-                .stock(request.getStock())
-                .price(request.getPrice())
-//                .values(optionCombinationValueList)
-                .build();
+    public void addOptionCombinationValue(OptionCombinationValue combinationValue) {
+        values.add(combinationValue);
     }
 
-    public static OptionCombination of(CreateOptionCombination.Request request) {
-        return OptionCombination.builder()
-                .stock(request.getStock())
-                .price(request.getPrice())
-                .build();
+    public static OptionCombination of(CreateOptionCombination.Request combinationDto, List<OptionValue> optionValues) {
+        OptionCombination optionCombination = OptionCombination.builder()
+                .stock(combinationDto.getStock())
+                .price(combinationDto.getPrice()).build();
+
+        combinationDto.getOptionCombinationValues()
+                .forEach(v -> optionCombination.addOptionCombinationValue(OptionCombinationValue.of(v, optionValues)));
+
+        return optionCombination;
     }
 }

--- a/product/src/main/java/com/commerce/product/product/domain/OptionCombinationValue.java
+++ b/product/src/main/java/com/commerce/product/product/domain/OptionCombinationValue.java
@@ -6,7 +6,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.List;
-import java.util.Objects;
 
 @Getter
 @Setter
@@ -22,39 +21,22 @@ public class OptionCombinationValue {
     private Long optionCombinationValueId;
 
     @ManyToOne
-    @JoinColumn(name = "option_combination_id")
-    private OptionCombination optionCombination;
-
-    @ManyToOne
-    @JoinColumn(name = "option_value_id")
+    @JoinColumn(name = "option_value_id", nullable = false)
     private OptionValue optionValue;
 
     public static OptionCombinationValue of(String value, List<OptionValue> optionValues) {
-        OptionValue savedOptionValue = getOptionValue(value, optionValues);
-
-        if (Objects.isNull(savedOptionValue)) {
-            throw new ProductException(ProductExceptionCode.NOT_MATCHED_OPTION_VALUE);
-        }
-
+        OptionValue optionValue = getOptionValue(value, optionValues);
         return OptionCombinationValue.builder()
-                .optionValue(savedOptionValue)
-                .build();
-    }
-
-    public static OptionCombinationValue of(OptionCombination optionCombination, OptionValue optionValue) {
-        return OptionCombinationValue.builder()
-                .optionCombination(optionCombination)
-                .optionValue(optionValue)
-                .build();
+                .optionValue(optionValue).build();
     }
 
     private static OptionValue getOptionValue(String value, List<OptionValue> optionValues) {
         for (OptionValue optionValue : optionValues) {
-            if (optionValue.isOptionValue(value)) {
+            if (optionValue.getOptionValue().equals(value)) {
                 return optionValue;
             }
         }
 
-        return null;
+        throw new ProductException(ProductExceptionCode.OPTION_VALUE_NOT_MATCHED);
     }
 }

--- a/product/src/main/java/com/commerce/product/product/domain/OptionValue.java
+++ b/product/src/main/java/com/commerce/product/product/domain/OptionValue.java
@@ -1,11 +1,12 @@
 package com.commerce.product.product.domain;
 
-import com.commerce.product.product.dto.CreateOptionValue;
-import jakarta.persistence.*;
-import lombok.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.commerce.product.product.dto.CreateOptionValue;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.*;
 
 @Getter
 @Setter
@@ -19,20 +20,7 @@ public class OptionValue {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long optionValueId;
-
     private String optionValue;
-
-/*    @Builder.Default
-    @OneToMany
-    private List<OptionCombinationValue> optionCombinationValues = new ArrayList<>();*/
-
-    @ManyToOne
-    @JoinColumn(name = "option_id")
-    private Option option;
-
-    public boolean isOptionValue(String value) {
-        return optionValue.equals(value);
-    }
 
     public static OptionValue of(CreateOptionValue.Request optionValueDto) {
         return OptionValue.builder()


### PR DESCRIPTION
상위 클래스에서 관리할 수 있도록 하여 비즈니스적으로 참조할 필요가 없는 객체의 참조를 끊어내고 부모에서 연관관계를 관리할 수 있도록 변경

질문

1. 말씀해주신대로 Combination을 분리하려고 시도를 했지만 CombinationValue와 OptionValue의 관계 때문에 분리하기가 어려웠습니다... (CombinationValue에서 OptionValue를 참조해야만 하는 이유 때문에) 어떤 방식이 있을까요...? ㅠㅠㅠ

2. https://github.com/manytoone 단방향 매핑 혹은 양방향 매핑만을 고려하고 설계를 했었습니다. @OneToMany 단방향으로 설정을 하게 된다면 추가로 update 쿼리가 발생하고 사용시에 잘못된 update 문이 발생할 수 있는 문제가 있어 지양하라는 글이나 책이 있어서 실제로 해보니 nullable조건 false로 주면 추가 update 쿼리없이 insert가 되고 예기치 못한 update문은 setter를 막아주어 해결할 수 있을 것 같은데 다른 문제점이나 고려해야 할 부분이 있을까요??
(너무 안좋은 말만 있어서 뭔가 ManyToOne 단방향 아니면 양방향으로 매핑을 해야할 것 같은 생각이 들게 됩니다...)

3. Entity로 변환 과정에서 OptionValue와 OptionCombinationValue와의 관계가 조금 특이해서 of메소드에서 OptionValue리스트를 만들어서 OptionCombination의 of메소드에 넘겨주어 처리하고 있습니다. 이 부분이 불편하지만(특히 OptionCombination의 of메소드는 관련도 없는데 거쳐가게 되는 부분) 연관관계를 설정하는 다른 방법이 생각이 나지 않아서 이렇게 구현했습니다. 이 부분이 나쁜 코드일까요...? ㅠㅠ